### PR TITLE
Adjust horizontal alignment of the year in the education description

### DIFF
--- a/app/accounts/templates/account/account.html
+++ b/app/accounts/templates/account/account.html
@@ -204,9 +204,9 @@
   }
 
   @media (min-width:992px) {
-    .timeline-one-side .timeline-content {
+    /* .timeline-one-side .timeline-content {
       max-width: 30rem
-    }
+    } */
   }
 
   .timeline-one-side .timeline-block:nth-child(even) .timeline-content {


### PR DESCRIPTION
### Adjust horizontal alignment of the year shown in the education section in account page
It was centred when screen is between 992px and 1200px
![image](https://user-images.githubusercontent.com/25697905/80391570-d1428380-88a5-11ea-891b-16c6975914ba.png)
